### PR TITLE
Fix hostname

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
-- manager.yaml
+  - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
-  newName: ghcr.io/stakater/grafana-cloud-ansible-operator
-  newTag: v0.0.23
+  - name: controller
+    newName: ghcr.io/stakater/grafana-cloud-ansible-operator
+    newTag: v0.0.23

--- a/config/manifests/bases/grafana-cloud-ansible-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/grafana-cloud-ansible-operator.clusterserviceversion.yaml
@@ -13,36 +13,36 @@ spec:
     Grafana Cloud
   displayName: grafana-cloud-operator
   icon:
-  - base64data: ""
-    mediatype: ""
+    - base64data: ""
+      mediatype: ""
   install:
     spec:
       deployments: null
     strategy: ""
   installModes:
-  - supported: true
-    type: OwnNamespace
-  - supported: true
-    type: SingleNamespace
-  - supported: false
-    type: MultiNamespace
-  - supported: false
-    type: AllNamespaces
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
   keywords:
-  - grafana-cloud
-  - oncall
-  - sre
-  - dashboard
-  - grafana-sre
-  - grafana-oncall
-  - slo
-  - grafana-slo
+    - grafana-cloud
+    - oncall
+    - sre
+    - dashboard
+    - grafana-sre
+    - grafana-oncall
+    - slo
+    - grafana-slo
   links:
-  - name: Grafana Cloud Ansible Operator
-    url: https://grafana-cloud-ansible-operator.domain
+    - name: Grafana Cloud Ansible Operator
+      url: https://grafana-cloud-ansible-operator.domain
   maintainers:
-  - email: hello@stakater.com
-    name: stakater
+    - email: hello@stakater.com
+      name: stakater
   maturity: alpha
   provider:
     name: Stakater

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_standalone.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_standalone.yml
@@ -26,8 +26,8 @@
 - name: Update hostname
   ansible.builtin.set_fact:
     cluster_name: >
-      "{{ node_info.resources[0].metadata.labels['kubernetes.io/hostname'] | regex_replace('-master.*', '')
-        | regex_replace('-worker.*', '') | regex_replace('-infra.*', '') }}"
+      {{ node_info.resources[0].metadata.labels['kubernetes.io/hostname'] | regex_replace('-master.*', '')
+        | regex_replace('-worker.*', '') | regex_replace('-infra.*', '') }}
 
 - name: Determine if integration exists for the cluster
   ansible.builtin.set_fact:


### PR DESCRIPTION
Adding block scaler multiline is causing Inverted commas at starting and ending of hostname. We didn't had that before. Fix for that