### PR TITLE
Run tasks on hubAndSpoke mode

### DIFF
--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -65,7 +65,7 @@
             patch: |
               data:
                 alertmanager.yaml: "{{ encoded_alertmanager_secret_content }}"
-  when: 
-  - create_integration_for | length > 0
-  - gco_cr.spec.provisionMode == 'hubAndSpoke'
+  when:
+    - create_integration_for | length > 0
+    - gco_cr.spec.provisionMode == 'hubAndSpoke'
   register: syncset_creation_results

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -41,6 +41,7 @@
 - name: Re-encode modified alertmanager content for cluster
   ansible.builtin.set_fact:
     encoded_alertmanager_secret_content: "{{ modified_alertmanager_secret_content | to_nice_yaml | b64encode }}"
+  when: gco_cr.spec.provisionMode == 'hubAndSpoke'
 
 - name: Create a new SyncSet for each cluster to patch alertmanager-main secret
   kubernetes.core.k8s:
@@ -64,5 +65,7 @@
             patch: |
               data:
                 alertmanager.yaml: "{{ encoded_alertmanager_secret_content }}"
-  when: create_integration_for | length > 0
+  when: 
+  - create_integration_for | length > 0
+  - gco_cr.spec.provisionMode == 'hubAndSpoke'
   register: syncset_creation_results


### PR DESCRIPTION
Condition added to run tasks that were fixed for hubAndSpoke mode only in the hubAndSpoke mode. We don't want to run syncset task in standalone mode.