### PR TITLE
Auto resolve alerts when Alertmanager marks them as Resolved

### DIFF
--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -7,7 +7,8 @@
               "name": receiver_name | trim,
               "webhook_configs": [
                 {
-                  "url": receiver_url
+                  "url": receiver_url,
+                  "send_resolved": true,
                 }
               ]
             },


### PR DESCRIPTION
Alert groups should be resolved when they are resolved in your alerting system, if the alert manager configuration includes send_resolved set to truein the receivers section, please refer to this document:
https://grafana.com/docs/grafana-cloud/alerting-and-irm/oncall/integrations/alertmanager/#configuring-alertmanager-to-send-alerts-to-grafana-oncall