### PR TITLE
Removes duplicate of registered managed clusters and Fixes status

### DIFF
--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -214,7 +214,7 @@
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"
 
-- name: Update CR status for SyncSet creation
+- name: Update CR status for ManifestWork creation
   operator_sdk.util.k8s_status:
     api_version: grafanacloud.stakater.com/v1alpha1
     kind: Config
@@ -225,15 +225,14 @@
         - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
           status: 'True'
           type: "Successful"
-          reason: "SyncSetsCreated"
-          message: "SyncSets created for all ManagedClusters"
+          reason: "ManifestWorksCreated"
+          message: "ManifestWorks created for all ManagedClusters"
   when: >
-    manifestwork_creation_results |
+    (manifestwork_creation_results |
     rejectattr('failed', 'equalto', true) |
-    list | length) == mapped_integrations |
-    length
+    list | length) == (mapped_integrations | length)
 
-- name: Update CR status for SyncSet creation failure
+- name: Update CR status for ManifestWork creation failure
   kubernetes.core.k8s:
     state: present
     definition:
@@ -245,8 +244,8 @@
       status:
         lastUpdated: "{{ ansible_date_time.iso8601 }}"
         phase: "Failed"
-        reason: "SyncSetCreationFailed"
-        message: "Failed to create SyncSet for one or more ManagedClusters"
+        reason: "ManifestWorkCreationFailed"
+        message: "Failed to create ManifestWork for one or more ManagedClusters"
     when: >
       manifestwork_creation_results |
       rejectattr('failed', 'equalto', false) | list | length > 0

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -227,10 +227,7 @@
           type: "Successful"
           reason: "ManifestWorksCreated"
           message: "ManifestWorks created for all ManagedClusters"
-  when: >
-    (manifestwork_creation_results |
-    rejectattr('failed', 'equalto', true) |
-    list | length) == (mapped_integrations | length)
+  when: not manifestwork_creation_results.failed
 
 - name: Update CR status for ManifestWork creation failure
   kubernetes.core.k8s:
@@ -246,6 +243,4 @@
         phase: "Failed"
         reason: "ManifestWorkCreationFailed"
         message: "Failed to create ManifestWork for one or more ManagedClusters"
-    when: >
-      manifestwork_creation_results |
-      rejectattr('failed', 'equalto', false) | list | length > 0
+  when: manifestwork_creation_results.failed

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -50,6 +50,10 @@
   loop_control:
     loop_var: item
 
+- name: Remove duplicate entries from managed_clusters
+  ansible.builtin.set_fact:
+    managed_clusters: "{{ managed_clusters | unique(attribute='name') }}"
+
 - name: Determine which ManagedCluster CRs don't have integrations
   ansible.builtin.set_fact:
     create_integration_for: "{{ managed_clusters | rejectattr('name', 'in', existing_integration_names) | list }}"


### PR DESCRIPTION
- Duplicate of Managed Clusters was creating integration twice causing 400 `status_code` which was registered as the status and the playbook failed to create ManifestWork
- Bug fix for status when ManifestWork is created or is failed to create. The conditions are adjusted using a debug statement when the ManifestWork creation responses are made. 