### PR TITLE
Gets cluster name and uuid with it in standalone mode

### DIFF
--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_standalone.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_standalone.yml
@@ -35,9 +35,9 @@
     api_version: operator.openshift.io/v1
   register: ingress_controller_info
 
-- name: Update hostname
+- name: Update hostname with cluster name and ID
   ansible.builtin.set_fact:
-    cluster_name: "{{ ingress_controller_info.resources[0].status.domain | regex_search('(?<=\\.)[^.]+(?=\\.)') }}"
+    cluster_name: "{{ ingress_controller_info.resources[0].status.domain | regex_search('(?<=\\.)[^.]+\\.[^.]+(?=\\.)') }}"
 
 - name: Determine if integration exists for the cluster
   ansible.builtin.set_fact:


### PR DESCRIPTION
- Having two clusters with the same name can be a possibility. To resolve that, we will pick up the uuid along with the cluster name in standalone mode to resolve similar names.