### PR TITLE
[SA-6478] Add owner label as a prefix while creating integration

### DIFF
--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -38,26 +38,16 @@
   ansible.builtin.set_fact:
     managed_clusters: []
 
-- name: Extract ManagedCluster names with prefix
-  ansible.builtin.set_fact:
-    managed_cluster_names: "{{ managed_cluster_names | default([]) + [item.metadata.name] }}"
-  loop: "{{ managed_clusters_raw.resources }}"
-  loop_control:
-    loop_var: item
-
-- name: Extract ManagedCluster owners with prefix
-  ansible.builtin.set_fact:
-    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + [item.metadata.labels.owner | default('unknown')] }}"
-  loop: "{{ managed_clusters_raw.resources }}"
-  loop_control:
-    loop_var: item
-
-- name: Combine managed_cluster_names and managed_cluster_owners into a list of strings
+- name: Extract list of ManagedCluster CRs with owners
   ansible.builtin.set_fact:
     managed_clusters: >-
       {{
-        managed_cluster_names
-        | zip(managed_cluster_owners)
+        managed_clusters_raw.resources
+        | map(attribute='metadata.name')
+        | zip(
+            managed_clusters_raw.resources
+            | map(attribute='metadata.labels.owner' | default('unknown'))
+          )
         | map('join', '-')
         | list
       }}
@@ -149,6 +139,22 @@
               message: "Clears old managed clusters"
       when: delete_integration_for
 
+    - name: Update CR status for IntegrationsDeleted
+      operator_sdk.util.k8s_status:
+        api_version: grafanacloud.stakater.com/v1alpha1
+        kind: Config
+        name: "{{ cr_name }}"
+        namespace: "{{ cr_namespace }}"
+        status:
+          managedClusters: "{{ managed_clusters }}"
+          conditions:
+            - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
+              status: "True"
+              type: "DeletionCompleted"
+              reason: "OperationDone"
+              message: "Deleted the integrations {{ delete_integration_for }}"
+      when: delete_integration_for
+
     - name: Deduplicate and clean up managedClusters status
       ansible.builtin.set_fact:
         cleaned_managed_clusters: >-
@@ -159,8 +165,9 @@
             | unique
             | list
           }}
+      when: delete_integration_for
 
-    - name: Update CR status for IntegrationsDeleted
+    - name: Update CR status with deduplicated ManagedClusters
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1
         kind: Config
@@ -171,9 +178,9 @@
           conditions:
             - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
               status: "True"
-              type: "DeletionCompleted"
-              reason: "OperationDone"
-              message: "Deleted the integrations {{ delete_integration_for }}"
+              type: "Updated"
+              reason: "Deduplicated"
+              message: "Removed duplicates and updated managedClusters status."
       when: delete_integration_for
 
     - name: Remove ManifestWork CR from cluster

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -38,16 +38,26 @@
   ansible.builtin.set_fact:
     managed_clusters: []
 
-- name: Extract list of ManagedCluster CRs with owners
+- name: Extract ManagedCluster names with prefix
+  ansible.builtin.set_fact:
+    managed_cluster_names: "{{ managed_cluster_names | default([]) + [item.metadata.name] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Extract ManagedCluster owners with prefix
+  ansible.builtin.set_fact:
+    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + [item.metadata.labels.owner | default('unknown')] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Combine managed_cluster_names and managed_cluster_owners into a list of strings
   ansible.builtin.set_fact:
     managed_clusters: >-
       {{
-        managed_clusters_raw.resources
-        | map(attribute='metadata.name')
-        | zip(
-            managed_clusters_raw.resources
-            | map(attribute='metadata.labels.owner' | default('unknown'))
-          )
+        managed_cluster_names
+        | zip(managed_cluster_owners)
         | map('join', '-')
         | list
       }}

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -34,6 +34,10 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
+- name: Initialize managed_clusters as an empty list
+  ansible.builtin.set_fact:
+    managed_clusters: []
+
 - name: Extract list of ManagedCluster CRs
   ansible.builtin.set_fact:
     managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name}] }}"

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -149,6 +149,17 @@
               message: "Clears old managed clusters"
       when: delete_integration_for
 
+    - name: Deduplicate and clean up managedClusters status
+      ansible.builtin.set_fact:
+        cleaned_managed_clusters: >-
+          {{
+            config_cr.resources[0].status.managedClusters
+            | map('regex_replace', '^name: ', '')
+            | map('regex_replace', '-owner: ', '-')
+            | unique
+            | list
+          }}
+
     - name: Update CR status for IntegrationsDeleted
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1
@@ -156,7 +167,7 @@
         name: "{{ cr_name }}"
         namespace: "{{ cr_namespace }}"
         status:
-          managedClusters: "{{ managed_clusters }}"
+          managedClusters: "{{ cleaned_managed_clusters }}"
           conditions:
             - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
               status: "True"

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -149,6 +149,19 @@
               message: "Clears old managed clusters"
       when: delete_integration_for
 
+    - name: Remove deleted integrations from managedClusters
+      ansible.builtin.set_fact:
+        updated_managed_clusters: >-
+          {{
+            config_cr.resources[0].status.managedClusters
+            | map('regex_replace', '^name: ', '')
+            | map('regex_replace', '-owner: ', '-')
+            | difference(delete_integration_for)
+            | unique
+            | list
+          }}
+      when: delete_integration_for | length > 0
+
     - name: Update CR status for IntegrationsDeleted
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1
@@ -156,41 +169,13 @@
         name: "{{ cr_name }}"
         namespace: "{{ cr_namespace }}"
         status:
-          managedClusters: "{{ managed_clusters }}"
+          managedClusters: "{{ updated_managed_clusters }}"
           conditions:
             - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
               status: "True"
               type: "DeletionCompleted"
               reason: "OperationDone"
               message: "Deleted the integrations {{ delete_integration_for }}"
-      when: delete_integration_for
-
-    - name: Deduplicate and clean up managedClusters status
-      ansible.builtin.set_fact:
-        cleaned_managed_clusters: >-
-          {{
-            config_cr.resources[0].status.managedClusters
-            | map('regex_replace', '^name: ', '')
-            | map('regex_replace', '-owner: ', '-')
-            | unique
-            | list
-          }}
-      when: delete_integration_for
-
-    - name: Update CR status with deduplicated ManagedClusters
-      operator_sdk.util.k8s_status:
-        api_version: grafanacloud.stakater.com/v1alpha1
-        kind: Config
-        name: "{{ cr_name }}"
-        namespace: "{{ cr_namespace }}"
-        status:
-          managedClusters: "{{ cleaned_managed_clusters }}"
-          conditions:
-            - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
-              status: "True"
-              type: "Updated"
-              reason: "Deduplicated"
-              message: "Removed duplicates and updated managedClusters status."
       when: delete_integration_for
 
     - name: Remove ManifestWork CR from cluster

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -38,16 +38,19 @@
   ansible.builtin.set_fact:
     managed_clusters: []
 
-- name: Extract list of ManagedCluster CRs
+- name: Extract list of ManagedCluster CRs with owners
   ansible.builtin.set_fact:
-    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name}] }}"
-  loop: "{{ managed_clusters_raw.resources }}"
-  loop_control:
-    loop_var: item
-
-- name: Determine which ManagedCluster CR doesn't have integrations
-  ansible.builtin.set_fact:
-    create_integration_for: "{{ managed_clusters | rejectattr('name', 'in', existing_integration_names) | list }}"
+    managed_clusters: >-
+      {{
+        managed_clusters_raw.resources
+        | map(attribute='metadata.name')
+        | zip(
+            managed_clusters_raw.resources
+            | map(attribute='metadata.labels.owner' | default('unknown'))
+          )
+        | map('join', '-')
+        | list
+      }}
 
 - name: Fetch current status of Config CR
   kubernetes.core.k8s_info:
@@ -61,13 +64,9 @@
   ansible.builtin.set_fact:
     previous_managed_clusters: "{{ config_cr.resources[0].status.managedClusters | default([]) }}"
 
-- name: Extract current ManagedCluster names
-  ansible.builtin.set_fact:
-    current_managed_clusters: "{{ managed_clusters | map(attribute='name') | list }}"
-
 - name: Determine integrations to delete in Grafana Cloud
   ansible.builtin.set_fact:
-    delete_integration_for: "{{ previous_managed_clusters | difference(current_managed_clusters) }}"
+    delete_integration_for: "{{ previous_managed_clusters | difference(managed_clusters) }}"
 
 - name: Delete integrations and dashboards when there are integrations to delete
   when: delete_integration_for | length > 0
@@ -147,7 +146,7 @@
         name: "{{ cr_name }}"
         namespace: "{{ cr_namespace }}"
         status:
-          managedClusters: "{{ current_managed_clusters }}"
+          managedClusters: "{{ managed_clusters }}"
           conditions:
             - lastTransitionTime: "{{ ansible_date_time.iso8601 }}"
               status: "True"
@@ -164,7 +163,7 @@
           kind: ManifestWork
           metadata:
             name: "{{ item.name }}-manifestwork-grafana-oncall"
-            namespace: "{{ item.name }}"
+            namespace: "{{ item.name | regex_replace('^(.+)-[^-]+$', '\\1') }}"
           spec:
             workload:
               manifests:
@@ -173,11 +172,10 @@
                   metadata:
                     name: alertmanager-main
                     namespace: openshift-monitoring
-      loop: "{{ integrations_to_delete }}"   # Ensure you have a loop here
+      loop: "{{ integrations_to_delete }}"
       loop_control:
         label: "{{ item.name }}"
-      when:
-        - delete_integration_for | length > 0
+      when: delete_integration_for | length > 0
       register: manifestwork_deletion_results
 
 - name: End play if any integrations failed or were skipped

--- a/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/delete_grafana_oncall_hub_spoke.yml
@@ -34,10 +34,12 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
+# This initializes the managed_cluster var as it has been used at other places in the playbook
 - name: Initialize managed_clusters as an empty list
   ansible.builtin.set_fact:
     managed_clusters: []
 
+# This will extract all the names from the ManagedCluster CR
 - name: Extract ManagedCluster names with prefix
   ansible.builtin.set_fact:
     managed_cluster_names: "{{ managed_cluster_names | default([]) + [item.metadata.name] }}"
@@ -45,6 +47,7 @@
   loop_control:
     loop_var: item
 
+# This will extract all the owner from the labels of ManagedCluster CR
 - name: Extract ManagedCluster owners with prefix
   ansible.builtin.set_fact:
     managed_cluster_owners: "{{ managed_cluster_owners | default([]) + [item.metadata.labels.owner | default('unknown')] }}"
@@ -52,6 +55,7 @@
   loop_control:
     loop_var: item
 
+# This combines both the name and owner as [managed_cluster_names]-[managed_cluster_owners] and saves it in var managed_cluster
 - name: Combine managed_cluster_names and managed_cluster_owners into a list of strings
   ansible.builtin.set_fact:
     managed_clusters: >-
@@ -74,6 +78,7 @@
   ansible.builtin.set_fact:
     previous_managed_clusters: "{{ config_cr.resources[0].status.managedClusters | default([]) }}"
 
+# Compares the Status field of Config CR with exsiting managed clusters in the clusters and then detemines which integrations to delete.
 - name: Determine integrations to delete in Grafana Cloud
   ansible.builtin.set_fact:
     delete_integration_for: "{{ previous_managed_clusters | difference(managed_clusters) }}"
@@ -133,6 +138,7 @@
       loop_control:
         loop_var: item
 
+    # This clears out the status field which was having existing managedCluster list
     - name: Removing old ManagedCluster List
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1
@@ -149,6 +155,7 @@
               message: "Clears old managed clusters"
       when: delete_integration_for
 
+    # This removes any duplications if found and stores the mangedCluster list with correct format [managed_cluster_name]-[managed_cluster_owner]
     - name: Remove deleted integrations from managedClusters
       ansible.builtin.set_fact:
         updated_managed_clusters: >-

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -289,7 +289,7 @@
       vars:
         receiver_name: "{{ item.grafana_details.name }}"
         receiver_url: "{{ item.grafana_details.link }}"
-        namespace: "{{ item.cluster.name }}"
+        namespace: "{{ item.cluster.name | regex_replace('^(.+?)(-new)?$', '\\1') }}"
         cluster_name: "{{ item.cluster.name }}"
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -116,7 +116,10 @@
       kubernetes.core.k8s_info:
         api_version: slack.stakater.com/v1alpha1
         kind: Channel
-        namespace: "{{ item.name }}"
+        # Strip everything from the last dash to the end. 
+        # e.g., "local-cluster-unknown" -> "local-cluster"
+        #       "2d23wd4e-epical"       -> "2d23wd4e"
+        namespace: "{{ item.name | regex_replace('^(.+)-[^-]+$', '\\1') }}"
       register: slack_channel_info
       loop: "{{ create_integration_for_dict }}"
       loop_control:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,20 +43,51 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-- name: Extract ManagedCluster details with owner label
+- name: Extract ManagedCluster details with name label
   ansible.builtin.set_fact:
-    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name, 'owner': item.metadata.labels.owner}] }}"
+    managed_clusters_create: "{{ managed_clusters_create | default([]) + [{'name': item.metadata.name}] }}"
   loop: "{{ managed_clusters_raw.resources }}"
   loop_control:
     loop_var: item
 
-- name: Remove duplicate entries from managed_clusters
+- name: Extract ManagedCluster names with prefix
   ansible.builtin.set_fact:
-    managed_clusters: "{{ managed_clusters | unique(attribute='name') }}"
+    managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Extract ManagedCluster owners with prefix
+  ansible.builtin.set_fact:
+    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + ['owner: ' ~ item.metadata.labels.owner | default('unknown')] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Combine managed_cluster_names and managed_cluster_owners into a dictionary
+  set_fact:
+    managed_clusters: >-
+      {{
+        dict(managed_cluster_names | zip(managed_cluster_owners))
+      }}
 
 - name: Determine which ManagedCluster CRs don't have integrations
   ansible.builtin.set_fact:
-    create_integration_for: "{{ managed_clusters | rejectattr('name', 'in', existing_integration_names) | list }}"
+    create_integration_for: "{{ managed_clusters_create | rejectattr('name', 'in', existing_integration_names) | list }}"
+
+- name: Add 'name:' prefix to integration_names
+  set_fact:
+    integration_names: "{{ create_integration_for | map(attribute='name') | map('regex_replace', '^', 'name: ') | list }}"
+
+- name: Filter common clusters for integration by name
+  set_fact:
+    common_clusters: >-
+      {{
+        managed_clusters
+        | dict2items
+        | selectattr('key', 'in', integration_names)
+        | items2dict
+      }}
 
 - name: Integration creation
   block:
@@ -100,7 +131,7 @@
           {{
             {
               "type": "alertmanager",
-              "name": (item.owner + '-' + item.name),
+              "name": (item.key | regex_replace('^name: ', '') + '-' + item.value | regex_replace('^owner: ', '')),
               "default_route": {
                 "slack": {
                   "channel_id": slack_channel_validated[loop_index].slack_id,
@@ -112,20 +143,19 @@
                  slack_channel_validated[loop_index].slack_id | length > 0
               else {
                 "type": "alertmanager",
-                "name": (item.owner + '-' + item.name)
+                "name": (item.key | regex_replace('^name: ', '') + '-' + item.value | regex_replace('^owner: ', ''))
               }
           }}
         status_code: [200, 201]
       register: grafana_integration_response
-      loop: "{{ create_integration_for }}"
+      loop: "{{ common_clusters | dict2items }}"
       loop_control:
-        label: "{{ item.name }}"
+        label: "{{ item.key }}"
         index_var: loop_index
       retries: 5
       delay: 6
       until: grafana_integration_response.status in [200, 201]
       failed_when: false
-
     - name: Update status with ManagedCluster field
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -257,10 +257,6 @@
           ansible.builtin.debug:
             msg: "Checking if Grafana integration for the cluster was skipped or failed."
 
-        - name: Debug grafana_integration_response
-          ansible.builtin.debug:
-            var: grafana_integration_response
-
         - name: Update CR status to Failure for failed integrations
           operator_sdk.util.k8s_status:
             api_version: grafanacloud.stakater.com/v1alpha1

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -271,9 +271,9 @@
                   reason: "IntegrationCreationFailed"
                   message: "Failed to create Grafana integration for ManagedClusters."
           loop: "{{ grafana_integration_response.results }}"
-          when: 
-           - item.status not in [200, 201]
-           - create_integration_for_dict is defined and create_integration_for_dict | length > 0
+          when:
+            - item.status not in [200, 201]
+            - create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
         - name: Start deletion for hubAndSpoke mode
           ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -285,7 +285,7 @@
 
     - name: Transform and set namespace for each cluster
       ansible.builtin.set_fact:
-        transformed_namespaces: "{{ transformed_namespaces | default([]) + [{'original': item.cluster.name, 'transformed': item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')}] }}"
+        transformed_namespaces: "{{ transformed_namespaces | default([]) + [{'original': item.cluster.name, 'transformed': item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')}] }}" # yamllint disable-line rule:line-length
       loop: "{{ mapped_integrations }}"
       loop_control:
         label: "{{ item.cluster.name }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -248,7 +248,7 @@
               type: "Successful"
               reason: "IntegrationsCreated"
               message: "Grafana integrations created for all ManagedClusters."
-      when: managed_cluster_names | length > 0
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Inform user if Grafana integration creation was skipped or failed
       when: grafana_integration_response is skipped or (grafana_integration_response.results | rejectattr('status', 'in', [200, 201]) | list | length > 0)

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -277,9 +277,6 @@
             - grafana_integration_response.results | length > 0
             - item.status not in [200, 201]
 
-        - name: Start deletion for hubAndSpoke mode
-          ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml
-
         - name: Associate Grafana integration details with ManagedClusters
           ansible.builtin.set_fact:
             mapped_integrations: >-
@@ -338,3 +335,6 @@
             reason: "ManifestWorkCreationFailed"
             message: "Failed to create ManifestWork for one or more ManagedClusters"
   when: manifestwork_creation_results.failed
+
+- name: Start deletion for hubAndSpoke mode
+  ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -276,6 +276,8 @@
             - grafana_integration_response.results is defined
             - grafana_integration_response.results | length > 0
             - item.status not in [200, 201]
+        
+        
 
     - name: Associate Grafana integration details with ManagedClusters
       ansible.builtin.set_fact:
@@ -289,6 +291,7 @@
       loop: "{{ mapped_integrations }}"
       loop_control:
         label: "{{ item.cluster.name }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     # Following tasks will execute only if Grafana integration was created successfully
     - name: Modify Alertmanager secret
@@ -333,6 +336,3 @@
             reason: "ManifestWorkCreationFailed"
             message: "Failed to create ManifestWork for one or more ManagedClusters"
   when: manifestwork_creation_results.failed
-
-- name: Start deletion for hubAndSpoke mode
-  ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -186,6 +186,7 @@
       delay: 6
       until: grafana_integration_response.status in [200, 201]
       failed_when: false
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Update status with ManagedCluster field
       operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,6 +43,7 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
+# Extracts name from MangedCluster and saves it like name: local-cluster 
 - name: Extract ManagedCluster names with prefix
   ansible.builtin.set_fact:
     managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
@@ -50,6 +51,7 @@
   loop_control:
     loop_var: item
 
+# Extracts owner from the ManagedCluster labels and saves it like owner: unknown
 - name: Extract ManagedCluster owners with prefix
   ansible.builtin.set_fact:
     managed_cluster_owners: "{{ managed_cluster_owners | default([]) + ['owner: ' ~ item.metadata.labels.owner | default('unknown')] }}"
@@ -57,6 +59,7 @@
   loop_control:
     loop_var: item
 
+# Removes name: and owner: and joins the managed_cluster_names and managed_cluster_owners with hyphen in between. e.g. local-cluster-unkonwn
 - name: Combine managed_cluster_names and managed_cluster_owners into a dictionary
   ansible.builtin.set_fact:
     managed_clusters: >-
@@ -71,6 +74,7 @@
         )
       }}
 
+# existing_integration_names comes fomr common_task via GET request and it has extracted names of integrations existing on Grafana Cloud. We add name: local-cluster-owner and store them as list to integration_names
 - name: Adds name as prefix to integration_names
   ansible.builtin.set_fact:
     integration_names: "{{ existing_integration_names | map('regex_replace', '^', 'name: ') | list }}"
@@ -85,6 +89,7 @@
         | items2dict
       }}
 
+# By comparing local available managedClusters CR names and existing_integration_names integrations names on grafana cloud we are creating a list for the integration to be created
 - name: Determine which ManagedCluster CRs don't have integrations (case-insensitive)
   ansible.builtin.set_fact:
     create_integration_for: >-
@@ -103,6 +108,7 @@
         | list
       }}
 
+# This creates a dictionary from the create_integration_for list to streamline with our usage ahead
 - name: Transform create_integration_for into a list of dictionaries
   ansible.builtin.set_fact:
     create_integration_for_dict: "{{ create_integration_for_dict | default([]) + [{'name': item}] }}"
@@ -112,6 +118,7 @@
 
 - name: Integration creation
   block:
+    # This will run only when we have create_integration_for_dict defined
     - name: Fetch Slack Channel from ManagedCluster namespace
       kubernetes.core.k8s_info:
         api_version: slack.stakater.com/v1alpha1
@@ -148,6 +155,7 @@
         label: "{{ item }}"
       when: slack_channel_ids is defined
 
+    # Creates the new integration with prefix added for customer e.g. local-cluster-unknown. Will run only once there's integration to be created
     - name: Create a new integration in Grafana OnCall integration for each ManagedClusters that does not have one
       ansible.builtin.uri:
         url: "{{ grafana_cloud_operator_grafana_cloud_integrations_api_url }}"
@@ -209,6 +217,9 @@
           }}
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
+      # This task processes the 'managed_clusters' dictionary to generate a list of ManagedCluster names
+      # with their associated prefixes. Each entry in the dictionary is transformed into a string in the 
+      # format "<prefix>-<name>". The resulting list is stored in 'managed_cluster_names'.
     - name: Extract new ManagedCluster names
       ansible.builtin.set_fact:
         managed_cluster_names: >-
@@ -283,6 +294,7 @@
       loop: "{{ grafana_integration_response.results }}"
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
+    # The namespace for ManagedCluster is without prefix of customer name. So we remove it here and store it as transformed_namespaces
     - name: Transform and set namespace for each cluster
       ansible.builtin.set_fact:
         transformed_namespaces: "{{ item.cluster.name | regex_replace('^(.*?)-.*$', '\\1') }}"
@@ -292,6 +304,7 @@
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     # Following tasks will execute only if Grafana integration was created successfully
+    # transformed_namespaces from above task it removes owner name from it and prints out as local-cluster
     - name: Modify Alertmanager secret
       ansible.builtin.include_tasks: modify_alertmanager_secret.yml
       vars:
@@ -303,6 +316,7 @@
       loop: "{{ mapped_integrations }}"
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
+# Skipped when manifestwork_creation_results is not defined
 - name: Update CR status for ManifestWork creation
   operator_sdk.util.k8s_status:
     api_version: grafanacloud.stakater.com/v1alpha1
@@ -318,6 +332,7 @@
           message: "ManifestWorks created for all ManagedClusters"
   when: manifestwork_creation_results is defined and not manifestwork_creation_results.failed
 
+# Skipped when manifestwork_creation_results is not defined
 - name: Update CR status for ManifestWork creation failure
   kubernetes.core.k8s:
     state: present
@@ -335,5 +350,6 @@
             message: "Failed to create ManifestWork for one or more ManagedClusters"
   when: manifestwork_creation_results is defined and not manifestwork_creation_results.failed
 
+# Moved to the bottom as we want to trigger deletion after all 
 - name: Start deletion for hubAndSpoke mode
   ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -316,7 +316,7 @@
           type: "Successful"
           reason: "ManifestWorksCreated"
           message: "ManifestWorks created for all ManagedClusters"
-  when: not manifestwork_creation_results.failed
+  when: manifestwork_creation_results is defined and not manifestwork_creation_results.failed
 
 - name: Update CR status for ManifestWork creation failure
   kubernetes.core.k8s:
@@ -333,7 +333,7 @@
             type: "Failed"
             reason: "ManifestWorkCreationFailed"
             message: "Failed to create ManifestWork for one or more ManagedClusters"
-  when: manifestwork_creation_results.failed
+  when: manifestwork_creation_results is defined and not manifestwork_creation_results.failed
 
 - name: Start deletion for hubAndSpoke mode
   ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -215,7 +215,6 @@
           }}
 
     - name: Merge existing ManagedCluster names with new ones
-    - name: Merge existing ManagedCluster names with new ones
       ansible.builtin.set_fact:
         updated_managed_cluster_names: >-
           {{

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -295,6 +295,7 @@
       loop: "{{ mapped_integrations }}"
       loop_control:
         label: "{{ item.cluster.name }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
 - name: Update CR status for ManifestWork creation
   operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -186,7 +186,6 @@
       delay: 6
       until: grafana_integration_response.status in [200, 201]
       failed_when: false
-      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Update status with ManagedCluster field
       operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -45,7 +45,7 @@
 
 - name: Extract ManagedCluster details with owner label
   ansible.builtin.set_fact:
-    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name, 'owner': item.metadata.labels.owner }}"
+    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name, 'owner': item.metadata.labels.owner}] }}"
   loop: "{{ managed_clusters_raw.resources }}"
   loop_control:
     loop_var: item

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -289,7 +289,7 @@
       vars:
         receiver_name: "{{ item.grafana_details.name }}"
         receiver_url: "{{ item.grafana_details.link }}"
-        namespace: "{{ item.cluster.name | regex_replace('^(.+?)(-new)?$', '\\1') }}"
+        namespace: "{{ item.cluster.name }}"
         cluster_name: "{{ item.cluster.name }}"
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -116,9 +116,6 @@
       kubernetes.core.k8s_info:
         api_version: slack.stakater.com/v1alpha1
         kind: Channel
-        # Strip everything from the last dash to the end.
-        # e.g., "local-cluster-unknown" -> "local-cluster"
-        #       "2d23wd4e-epical"       -> "2d23wd4e"
         namespace: "{{ item.name | regex_replace('^(.+)-[^-]+$', '\\1') }}"
       register: slack_channel_info
       loop: "{{ create_integration_for_dict }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -176,7 +176,7 @@
 
     - name: Set fact for list of ManagedCluster names
       ansible.builtin.set_fact:
-        managed_cluster_names: "{{ managed_cluster_owners | map(attribute='name') | list }}"
+        managed_cluster_names: "{{ managed_clusters_create | map(attribute='name') | list }}"
       when: create_integration_for | length == grafana_integration_response.results | length
 
     - name: Merge existing ManagedCluster names with new ones

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -285,7 +285,7 @@
 
     - name: Transform and set namespace for each cluster
       ansible.builtin.set_fact:
-        transformed_namespaces: "{{ transformed_namespaces | default([]) + [{'original': item.cluster.name, 'transformed': item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')}] }}" # yamllint disable-line rule:line-length
+        transformed_namespaces: "{{ transformed_namespaces | default([]) + [item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')] }}"
       loop: "{{ mapped_integrations }}"
       loop_control:
         label: "{{ item.cluster.name }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -131,12 +131,19 @@
 
     - name: Populate List with spaces if any
       vars:
-        slack_id_fetched: "{{ slack_channel_ids | selectattr('name', 'contains', item.name) | map(attribute='slack_id') | join(',') }}"
+        slack_id_fetched: >-
+          {{
+            slack_channel_ids
+            | default([])
+            | selectattr('name', 'contains', item)
+            | map(attribute='slack_id')
+            | join(',')
+          }}
       ansible.builtin.set_fact:
-        slack_channel_validated: "{{ slack_channel_validated | default([]) + [{'name': item.name, 'slack_id': slack_id_fetched}] }}"
+        slack_channel_validated: "{{ slack_channel_validated | default([]) + [{'name': item, 'slack_id': slack_id_fetched}] }}"
       loop: "{{ create_integration_for }}"
       loop_control:
-        label: "{{ item.name }}"
+        label: "{{ item }}"
       when: slack_channel_ids is defined
 
     - name: Create a new integration in Grafana OnCall integration for each ManagedClusters that does not have one

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -277,19 +277,11 @@
             - grafana_integration_response.results | length > 0
             - item.status not in [200, 201]
 
-        - name: Associate Grafana integration details with ManagedClusters
-          ansible.builtin.set_fact:
-            mapped_integrations: >-
-              {{
-                mapped_integrations | default([]) + [
-                  {
-                    'cluster': item.item,
-                    'grafana_details': item.json
-                  }
-                ]
-              }}
-          loop: "{{ grafana_integration_response.results | default([]) }}"
-          when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
+    - name: Associate Grafana integration details with ManagedClusters
+      ansible.builtin.set_fact:
+        mapped_integrations: "{{ mapped_integrations | default([]) + [{'cluster': item.item, 'grafana_details': item.json}] }}"
+      loop: "{{ grafana_integration_response.results }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     # Following tasks will execute only if Grafana integration was created successfully
     - name: Modify Alertmanager secret

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -65,7 +65,7 @@
     loop_var: item
 
 - name: Combine managed_cluster_names and managed_cluster_owners into a dictionary
-  set_fact:
+  ansible.builtin.set_fact:
     managed_clusters: >-
       {{
         dict(managed_cluster_names | zip(managed_cluster_owners))
@@ -76,11 +76,11 @@
     create_integration_for: "{{ managed_clusters_create | rejectattr('name', 'in', existing_integration_names) | list }}"
 
 - name: Add 'name:' prefix to integration_names
-  set_fact:
+  ansible.builtin.set_fact:
     integration_names: "{{ create_integration_for | map(attribute='name') | map('regex_replace', '^', 'name: ') | list }}"
 
 - name: Filter common clusters for integration by name
-  set_fact:
+  ansible.builtin.set_fact:
     common_clusters: >-
       {{
         managed_clusters

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -129,6 +129,7 @@
       loop: "{{ slack_channel_info.results | map(attribute='resources') | flatten }}"
       loop_control:
         label: "{{ item.metadata.name }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Populate List with spaces if any
       vars:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -285,7 +285,7 @@
 
     - name: Transform and set namespace for each cluster
       ansible.builtin.set_fact:
-        transformed_namespaces: "{{ transformed_namespaces | default([]) + [item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')] }}"
+        transformed_namespaces: "{{ item.cluster.name | regex_replace('^(.*?)-.*$', '\\1') }}"
       loop: "{{ mapped_integrations }}"
       loop_control:
         label: "{{ item.cluster.name }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -152,7 +152,7 @@
           {{
             {
               "type": "alertmanager",
-              "name": (item.key | regex_replace('^name: ', '') + '-' + item.value | regex_replace('^owner: ', '')),
+              "name": item.name,
               "default_route": {
                 "slack": {
                   "channel_id": slack_channel_validated[loop_index].slack_id,
@@ -160,16 +160,16 @@
                 }
               }
             } if slack_channel_validated is defined and
-                 slack_channel_validated | length > loop_index and
-                 slack_channel_validated[loop_index].slack_id | length > 0
+                slack_channel_validated | length > loop_index and
+                slack_channel_validated[loop_index].slack_id | length > 0
               else {
                 "type": "alertmanager",
-                "name": (item.key | regex_replace('^name: ', '') + '-' + item.value | regex_replace('^owner: ', ''))
+                "name": item.name
               }
           }}
         status_code: [200, 201]
       register: grafana_integration_response
-      loop: "{{ common_clusters | dict2items }}"
+      loop: "{{ create_integration_for_dict }}"
       loop_control:
         label: "{{ item.key }}"
         index_var: loop_index
@@ -192,21 +192,35 @@
 
     - name: Extract existing ManagedCluster names from current status
       ansible.builtin.set_fact:
-        existing_managed_cluster_names: "{{ current_config_cr.resources[0].status.managedClusters | list | default([]) }}"
-      when: create_integration_for | length == grafana_integration_response.results | length
+        existing_managed_cluster_names: >-
+          {{
+            current_config_cr.resources[0].status.managed_clusters
+            | default([])
+          }}
 
-    - name: Set fact for list of ManagedCluster names
+    - name: Extract new ManagedCluster names
       ansible.builtin.set_fact:
-        managed_cluster_names: "{{ managed_clusters | map(attribute='name') | list }}"
-      when: create_integration_for | length == grafana_integration_response.results | length
+        managed_cluster_names: >-
+          {{
+            managed_clusters
+            | dict2items
+            | map(attribute='key')
+            | zip(
+                managed_clusters
+                | dict2items
+                | map(attribute='value')
+              )
+            | map('join', '-')
+            | list
+          }}
 
+    - name: Merge existing ManagedCluster names with new ones
     - name: Merge existing ManagedCluster names with new ones
       ansible.builtin.set_fact:
         updated_managed_cluster_names: >-
           {{
             (existing_managed_cluster_names + managed_cluster_names) | unique
           }}
-      when: create_integration_for | length == grafana_integration_response.results | length
 
     - name: Update CR status to IntegrationsCreated
       operator_sdk.util.k8s_status:
@@ -222,7 +236,7 @@
               type: "Successful"
               reason: "IntegrationsCreated"
               message: "Grafana integrations created for all ManagedClusters."
-      when: create_integration_for | length == grafana_integration_response.results | length
+      when: managed_cluster_names | length > 0
 
     - name: Inform user if Grafana integration creation was skipped or failed
       when: grafana_integration_response is skipped or (grafana_integration_response.results | rejectattr('status', 'in', [200, 201]) | list | length > 0)

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -121,6 +121,7 @@
       loop: "{{ create_integration_for_dict }}"
       loop_control:
         label: "{{ item.name }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Extract Channel id from slack channel
       ansible.builtin.set_fact:
@@ -204,6 +205,7 @@
             current_config_cr.resources[0].status.managed_clusters
             | default([])
           }}
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Extract new ManagedCluster names
       ansible.builtin.set_fact:
@@ -220,6 +222,7 @@
             | map('join', '-')
             | list
           }}
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Merge existing ManagedCluster names with new ones
       ansible.builtin.set_fact:
@@ -227,6 +230,7 @@
           {{
             (existing_managed_cluster_names + managed_cluster_names) | unique
           }}
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Update CR status to IntegrationsCreated
       operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -289,12 +289,10 @@
       vars:
         receiver_name: "{{ item.grafana_details.name }}"
         receiver_url: "{{ item.grafana_details.link }}"
-        namespace: "{{ item.cluster.name }}"
+        namespace: "{{ item.cluster.name | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
         cluster_name: "{{ item.cluster.name }}"
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"
-      loop_control:
-        label: "{{ item.cluster.name }}"
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
 - name: Update CR status for ManifestWork creation

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,7 +43,7 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-# Extracts name from MangedCluster and saves it like name: local-cluster 
+# Extracts name from MangedCluster and saves it like name: local-cluster
 - name: Extract ManagedCluster names with prefix
   ansible.builtin.set_fact:
     managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
@@ -74,7 +74,9 @@
         )
       }}
 
-# existing_integration_names comes fomr common_task via GET request and it has extracted names of integrations existing on Grafana Cloud. We add name: local-cluster-owner and store them as list to integration_names
+# existing_integration_names comes fomr common_task via GET request
+# and it has extracted names of integrations existing on Grafana Cloud.
+# We add name: local-cluster-owner and store them as list to integration_names
 - name: Adds name as prefix to integration_names
   ansible.builtin.set_fact:
     integration_names: "{{ existing_integration_names | map('regex_replace', '^', 'name: ') | list }}"
@@ -89,7 +91,8 @@
         | items2dict
       }}
 
-# By comparing local available managedClusters CR names and existing_integration_names integrations names on grafana cloud we are creating a list for the integration to be created
+# By comparing local available managedClusters CR names and existing_integration_names
+# integrations names on grafana cloud we are creating a list for the integration to be created
 - name: Determine which ManagedCluster CRs don't have integrations (case-insensitive)
   ansible.builtin.set_fact:
     create_integration_for: >-
@@ -108,7 +111,8 @@
         | list
       }}
 
-# This creates a dictionary from the create_integration_for list to streamline with our usage ahead
+# This creates a dictionary from the create_integration_for
+# list to streamline with our usage ahead
 - name: Transform create_integration_for into a list of dictionaries
   ansible.builtin.set_fact:
     create_integration_for_dict: "{{ create_integration_for_dict | default([]) + [{'name': item}] }}"
@@ -155,7 +159,8 @@
         label: "{{ item }}"
       when: slack_channel_ids is defined
 
-    # Creates the new integration with prefix added for customer e.g. local-cluster-unknown. Will run only once there's integration to be created
+    # Creates the new integration with prefix added for customer e.g.
+    # local-cluster-unknown. Will run only once there's integration to be created
     - name: Create a new integration in Grafana OnCall integration for each ManagedClusters that does not have one
       ansible.builtin.uri:
         url: "{{ grafana_cloud_operator_grafana_cloud_integrations_api_url }}"
@@ -218,7 +223,7 @@
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
       # This task processes the 'managed_clusters' dictionary to generate a list of ManagedCluster names
-      # with their associated prefixes. Each entry in the dictionary is transformed into a string in the 
+      # with their associated prefixes. Each entry in the dictionary is transformed into a string in the
       # format "<prefix>-<name>". The resulting list is stored in 'managed_cluster_names'.
     - name: Extract new ManagedCluster names
       ansible.builtin.set_fact:
@@ -294,7 +299,8 @@
       loop: "{{ grafana_integration_response.results }}"
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
-    # The namespace for ManagedCluster is without prefix of customer name. So we remove it here and store it as transformed_namespaces
+    # The namespace for ManagedCluster is without prefix
+    # of customer name. So we remove it here and store it as transformed_namespaces
     - name: Transform and set namespace for each cluster
       ansible.builtin.set_fact:
         transformed_namespaces: "{{ item.cluster.name | regex_replace('^(.*?)-.*$', '\\1') }}"
@@ -350,6 +356,6 @@
             message: "Failed to create ManifestWork for one or more ManagedClusters"
   when: manifestwork_creation_results is defined and not manifestwork_creation_results.failed
 
-# Moved to the bottom as we want to trigger deletion after all 
+# Moved to the bottom as we want to trigger deletion after all
 - name: Start deletion for hubAndSpoke mode
   ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -198,7 +198,7 @@
           managedClusters: []
       when:
         - "'managedClusters' not in current_config_cr.resources[0].status"
-        - create_integration_for | length == grafana_integration_response.results | length
+        - create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Extract existing ManagedCluster names from current status
       ansible.builtin.set_fact:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -180,13 +180,12 @@
       register: grafana_integration_response
       loop: "{{ create_integration_for_dict }}"
       loop_control:
-        label: "{{ item.key }}"
+        label: "{{ item.name }}"
         index_var: loop_index
       retries: 5
       delay: 6
       until: grafana_integration_response.status in [200, 201]
       failed_when: false
-      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     - name: Update status with ManagedCluster field
       operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -176,7 +176,7 @@
 
     - name: Set fact for list of ManagedCluster names
       ansible.builtin.set_fact:
-        managed_cluster_names: "{{ managed_clusters | map(attribute='name') | list }}"
+        managed_cluster_names: "{{ managed_cluster_owners | map(attribute='name') | list }}"
       when: create_integration_for | length == grafana_integration_response.results | length
 
     - name: Merge existing ManagedCluster names with new ones

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -276,8 +276,10 @@
                   message: "Failed to create Grafana integration for ManagedClusters."
           loop: "{{ grafana_integration_response.results }}"
           when:
+            - grafana_integration_response is defined
+            - grafana_integration_response.results is defined
+            - grafana_integration_response.results | length > 0
             - item.status not in [200, 201]
-            - create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
         - name: Start deletion for hubAndSpoke mode
           ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -257,6 +257,10 @@
           ansible.builtin.debug:
             msg: "Checking if Grafana integration for the cluster was skipped or failed."
 
+        - name: Debug grafana_integration_response
+          ansible.builtin.debug:
+            var: grafana_integration_response
+
         - name: Update CR status to Failure for failed integrations
           operator_sdk.util.k8s_status:
             api_version: grafanacloud.stakater.com/v1alpha1

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -276,8 +276,6 @@
             - grafana_integration_response.results is defined
             - grafana_integration_response.results | length > 0
             - item.status not in [200, 201]
-        
-        
 
     - name: Associate Grafana integration details with ManagedClusters
       ansible.builtin.set_fact:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,7 +43,7 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-- name: Extract ManagedCluster details with name label
+- name: Extract ManagedCluster details with name
   ansible.builtin.set_fact:
     managed_clusters_create: "{{ managed_clusters_create | default([]) + [{'name': item.metadata.name}] }}"
   loop: "{{ managed_clusters_raw.resources }}"
@@ -75,7 +75,7 @@
   ansible.builtin.set_fact:
     create_integration_for: "{{ managed_clusters_create | rejectattr('name', 'in', existing_integration_names) | list }}"
 
-- name: Add 'name:' prefix to integration_names
+- name: Adds name as prefix to integration_names
   ansible.builtin.set_fact:
     integration_names: "{{ create_integration_for | map(attribute='name') | map('regex_replace', '^', 'name: ') | list }}"
 

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -286,7 +286,7 @@
               {{
                 mapped_integrations | default([]) + [
                   {
-                    'cluster': item.item,  # Ensure this aligns with the loop structure
+                    'cluster': item.item,
                     'grafana_details': item.json
                   }
                 ]

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -156,6 +156,7 @@
       delay: 6
       until: grafana_integration_response.status in [200, 201]
       failed_when: false
+
     - name: Update status with ManagedCluster field
       operator_sdk.util.k8s_status:
         api_version: grafanacloud.stakater.com/v1alpha1

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,13 +43,6 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-- name: Extract ManagedCluster details with name
-  ansible.builtin.set_fact:
-    managed_clusters_create: "{{ managed_clusters_create | default([]) + [{'name': item.metadata.name}] }}"
-  loop: "{{ managed_clusters_raw.resources }}"
-  loop_control:
-    loop_var: item
-
 - name: Extract ManagedCluster names with prefix
   ansible.builtin.set_fact:
     managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
@@ -68,16 +61,19 @@
   ansible.builtin.set_fact:
     managed_clusters: >-
       {{
-        dict(managed_cluster_names | zip(managed_cluster_owners))
+        dict(
+          managed_cluster_names
+          | map('regex_replace', '^name: ', '')
+          | zip(
+              managed_cluster_owners
+              | map('regex_replace', '^owner: ', '')
+            )
+        )
       }}
-
-- name: Determine which ManagedCluster CRs don't have integrations
-  ansible.builtin.set_fact:
-    create_integration_for: "{{ managed_clusters_create | rejectattr('name', 'in', existing_integration_names) | list }}"
 
 - name: Adds name as prefix to integration_names
   ansible.builtin.set_fact:
-    integration_names: "{{ create_integration_for | map(attribute='name') | map('regex_replace', '^', 'name: ') | list }}"
+    integration_names: "{{ existing_integration_names | map('regex_replace', '^', 'name: ') | list }}"
 
 - name: Filter common clusters for integration by name
   ansible.builtin.set_fact:
@@ -89,6 +85,31 @@
         | items2dict
       }}
 
+- name: Determine which ManagedCluster CRs don't have integrations (case-insensitive)
+  ansible.builtin.set_fact:
+    create_integration_for: >-
+      {{
+        managed_clusters
+        | dict2items
+        | map(attribute='key')
+        | zip(
+            managed_clusters | dict2items | map(attribute='value')
+        )
+        | map('join', '-')
+        | reject('in', integration_names
+          | map('regex_replace', '^name: ', '')
+          | map('lower')
+        | list)
+        | list
+      }}
+
+- name: Transform create_integration_for into a list of dictionaries
+  ansible.builtin.set_fact:
+    create_integration_for_dict: "{{ create_integration_for_dict | default([]) + [{'name': item}] }}"
+  loop: "{{ create_integration_for }}"
+  loop_control:
+    loop_var: item
+
 - name: Integration creation
   block:
     - name: Fetch Slack Channel from ManagedCluster namespace
@@ -97,7 +118,7 @@
         kind: Channel
         namespace: "{{ item.name }}"
       register: slack_channel_info
-      loop: "{{ create_integration_for }}"
+      loop: "{{ create_integration_for_dict }}"
       loop_control:
         label: "{{ item.name }}"
 
@@ -176,7 +197,7 @@
 
     - name: Set fact for list of ManagedCluster names
       ansible.builtin.set_fact:
-        managed_cluster_names: "{{ managed_clusters_create | map(attribute='name') | list }}"
+        managed_cluster_names: "{{ managed_clusters | map(attribute='name') | list }}"
       when: create_integration_for | length == grafana_integration_response.results | length
 
     - name: Merge existing ManagedCluster names with new ones

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -116,7 +116,7 @@
       kubernetes.core.k8s_info:
         api_version: slack.stakater.com/v1alpha1
         kind: Channel
-        # Strip everything from the last dash to the end. 
+        # Strip everything from the last dash to the end.
         # e.g., "local-cluster-unknown" -> "local-cluster"
         #       "2d23wd4e-epical"       -> "2d23wd4e"
         namespace: "{{ item.name | regex_replace('^(.+)-[^-]+$', '\\1') }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -280,11 +280,19 @@
         - name: Start deletion for hubAndSpoke mode
           ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml
 
-    - name: Associate Grafana integration details with ManagedClusters
-      ansible.builtin.set_fact:
-        mapped_integrations: "{{ mapped_integrations | default([]) + [{'cluster': item.item, 'grafana_details': item.json}] }}"
-      loop: "{{ grafana_integration_response.results }}"
-      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
+        - name: Associate Grafana integration details with ManagedClusters
+          ansible.builtin.set_fact:
+            mapped_integrations: >-
+              {{
+                mapped_integrations | default([]) + [
+                  {
+                    'cluster': item.item,  # Ensure this aligns with the loop structure
+                    'grafana_details': item.json
+                  }
+                ]
+              }}
+          loop: "{{ grafana_integration_response.results | default([]) }}"
+          when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     # Following tasks will execute only if Grafana integration was created successfully
     - name: Modify Alertmanager secret
@@ -296,6 +304,8 @@
         cluster_name: "{{ item.cluster.name }}"
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"
+      loop_control:
+        label: "{{ item.cluster.name }}"
 
 - name: Update CR status for ManifestWork creation
   operator_sdk.util.k8s_status:

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -283,13 +283,20 @@
       loop: "{{ grafana_integration_response.results }}"
       when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
+    - name: Transform and set namespace for each cluster
+      ansible.builtin.set_fact:
+        transformed_namespaces: "{{ transformed_namespaces | default([]) + [{'original': item.cluster.name, 'transformed': item.cluster.name | regex_replace('^(.*?)-.*$', '\\1')}] }}"
+      loop: "{{ mapped_integrations }}"
+      loop_control:
+        label: "{{ item.cluster.name }}"
+
     # Following tasks will execute only if Grafana integration was created successfully
     - name: Modify Alertmanager secret
       ansible.builtin.include_tasks: modify_alertmanager_secret.yml
       vars:
         receiver_name: "{{ item.grafana_details.name }}"
         receiver_url: "{{ item.grafana_details.link }}"
-        namespace: "{{ item.cluster.name | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
+        namespace: "{{ transformed_namespaces  }}"
         cluster_name: "{{ item.cluster.name }}"
         provision_mode: "hubAndSpoke"
       loop: "{{ mapped_integrations }}"

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -334,3 +334,6 @@
             reason: "ManifestWorkCreationFailed"
             message: "Failed to create ManifestWork for one or more ManagedClusters"
   when: manifestwork_creation_results.failed
+
+- name: Start deletion for hubAndSpoke mode
+  ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -43,9 +43,9 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-- name: Extract the list of ManagedCluster CRs
+- name: Extract ManagedCluster details with owner label
   ansible.builtin.set_fact:
-    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name}] }}"
+    managed_clusters: "{{ managed_clusters | default([]) + [{'name': item.metadata.name, 'owner': item.metadata.labels.owner }}"
   loop: "{{ managed_clusters_raw.resources }}"
   loop_control:
     loop_var: item
@@ -100,19 +100,19 @@
           {{
             {
               "type": "alertmanager",
-              "name": item.name,
+              "name": (item.owner + '-' + item.name),
               "default_route": {
-              "slack": {
-                    "channel_id": slack_channel_validated[loop_index].slack_id,
-                    "enabled": slack_cond
-                  }
+                "slack": {
+                  "channel_id": slack_channel_validated[loop_index].slack_id,
+                  "enabled": slack_cond
                 }
-              } if slack_channel_validated is defined and
-                   slack_channel_validated | length > loop_index and
-                   slack_channel_validated[loop_index].slack_id | length > 0
-                else {
-                  "type": "alertmanager",
-                  "name": item.name
+              }
+            } if slack_channel_validated is defined and
+                 slack_channel_validated | length > loop_index and
+                 slack_channel_validated[loop_index].slack_id | length > 0
+              else {
+                "type": "alertmanager",
+                "name": (item.owner + '-' + item.name)
               }
           }}
         status_code: [200, 201]

--- a/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_oncall_hub_spoke.yml
@@ -271,7 +271,9 @@
                   reason: "IntegrationCreationFailed"
                   message: "Failed to create Grafana integration for ManagedClusters."
           loop: "{{ grafana_integration_response.results }}"
-          when: item.status not in [200, 201]
+          when: 
+           - item.status not in [200, 201]
+           - create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
         - name: Start deletion for hubAndSpoke mode
           ansible.builtin.include_tasks: delete_grafana_oncall_hub_spoke.yml
@@ -280,6 +282,7 @@
       ansible.builtin.set_fact:
         mapped_integrations: "{{ mapped_integrations | default([]) + [{'cluster': item.item, 'grafana_details': item.json}] }}"
       loop: "{{ grafana_integration_response.results }}"
+      when: create_integration_for_dict is defined and create_integration_for_dict | length > 0
 
     # Following tasks will execute only if Grafana integration was created successfully
     - name: Modify Alertmanager secret

--- a/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
@@ -18,6 +18,7 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
+# Extracts the name from ManagedCluster CR
 - name: Extract ManagedCluster names
   ansible.builtin.set_fact:
     managed_cluster_names: "{{ managed_cluster_names | default([]) + [item.metadata.name] }}"
@@ -25,6 +26,7 @@
   loop_control:
     loop_var: item
 
+# Extracts the owner from ManagedCluster CR
 - name: Extract ManagedCluster owners
   ansible.builtin.set_fact:
     managed_cluster_owners: "{{ managed_cluster_owners | default([]) + [item.metadata.labels.owner | default('unknown')] }}"
@@ -32,6 +34,7 @@
   loop_control:
     loop_var: item
 
+# Combines them into a list
 - name: Combine ManagedCluster names and owners into a list of strings
   ansible.builtin.set_fact:
     current_managed_clusters: >-

--- a/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
@@ -46,7 +46,7 @@
         )
       }}
 
-- name: Convert managed_clusters to format
+- name: Convert managed_clusters to <clusterID>-<owner> format
   ansible.builtin.set_fact:
     current_managed_clusters: "{{ managed_clusters | dict2items | map('join', '-') | list }}"
 

--- a/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
@@ -18,37 +18,29 @@
     kind: ManagedCluster
   register: managed_clusters_raw
 
-- name: Extract ManagedCluster names with prefix
+- name: Extract ManagedCluster names
   ansible.builtin.set_fact:
-    managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
+    managed_cluster_names: "{{ managed_cluster_names | default([]) + [item.metadata.name] }}"
   loop: "{{ managed_clusters_raw.resources }}"
   loop_control:
     loop_var: item
 
-- name: Extract ManagedCluster owners with prefix
+- name: Extract ManagedCluster owners
   ansible.builtin.set_fact:
-    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + ['owner: ' ~ item.metadata.labels.owner | default('unknown')] }}"
+    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + [item.metadata.labels.owner | default('unknown')] }}"
   loop: "{{ managed_clusters_raw.resources }}"
   loop_control:
     loop_var: item
 
-- name: Combine managed_cluster_names and managed_cluster_owners into a dictionary
+- name: Combine ManagedCluster names and owners into a list of strings
   ansible.builtin.set_fact:
-    managed_clusters: >-
+    current_managed_clusters: >-
       {{
-        dict(
-          managed_cluster_names
-          | map('regex_replace', '^name: ', '')
-          | zip(
-              managed_cluster_owners
-              | map('regex_replace', '^owner: ', '')
-            )
-        )
+        managed_cluster_names
+        | zip(managed_cluster_owners)
+        | map('join', '-')
+        | list
       }}
-
-- name: Convert managed_clusters to <clusterID>-<owner> format
-  ansible.builtin.set_fact:
-    current_managed_clusters: "{{ managed_clusters | dict2items | map('join', '-') | list }}"
 
 - name: Get all folders in Grafana Cloud
   ansible.builtin.uri:

--- a/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
@@ -12,6 +12,44 @@
           reason: "OperationStarted"
           message: "Starting creation of SLO dashboard in hubAndSpoke mode"
 
+- name: Fetch ManagedCluster CRs
+  kubernetes.core.k8s_info:
+    api_version: cluster.open-cluster-management.io/v1
+    kind: ManagedCluster
+  register: managed_clusters_raw
+
+- name: Extract ManagedCluster names with prefix
+  ansible.builtin.set_fact:
+    managed_cluster_names: "{{ managed_cluster_names | default([]) + ['name: ' ~ item.metadata.name] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Extract ManagedCluster owners with prefix
+  ansible.builtin.set_fact:
+    managed_cluster_owners: "{{ managed_cluster_owners | default([]) + ['owner: ' ~ item.metadata.labels.owner | default('unknown')] }}"
+  loop: "{{ managed_clusters_raw.resources }}"
+  loop_control:
+    loop_var: item
+
+- name: Combine managed_cluster_names and managed_cluster_owners into a dictionary
+  ansible.builtin.set_fact:
+    managed_clusters: >-
+      {{
+        dict(
+          managed_cluster_names
+          | map('regex_replace', '^name: ', '')
+          | zip(
+              managed_cluster_owners
+              | map('regex_replace', '^owner: ', '')
+            )
+        )
+      }}
+
+- name: Convert managed_clusters to <clusterID>-<owner> format
+  ansible.builtin.set_fact:
+    current_managed_clusters: "{{ managed_clusters | dict2items | map('join', '-') | list }}"
+
 - name: Get all folders in Grafana Cloud
   ansible.builtin.uri:
     url: "{{ gco_cr.spec.sloCloudAPI }}/folders"

--- a/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
+++ b/roles/grafana_cloud_operator/tasks/grafana_slo_hub_spoke.yml
@@ -46,7 +46,7 @@
         )
       }}
 
-- name: Convert managed_clusters to <clusterID>-<owner> format
+- name: Convert managed_clusters to format
   ansible.builtin.set_fact:
     current_managed_clusters: "{{ managed_clusters | dict2items | map('join', '-') | list }}"
 

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -80,7 +80,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ namespace | regex_replace('^(.*?)(-new)?$', '\\1') | default('default-namespace') }}"
+        namespace: "{{ namespace | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
       spec:
         workload:
           manifests:

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -80,7 +80,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ namespace | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
+        namespace: "{{ namespace }}"
       spec:
         workload:
           manifests:

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -80,7 +80,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ item.cluster.name | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
+        namespace: "{{ namespace }}"
       spec:
         workload:
           manifests:

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -72,13 +72,6 @@
     provision_mode_check: "{{ provision_mode }}"
   when: provision_mode_check == "hubAndSpoke"
 
-- name: Adjust namespace if necessary
-  ansible.builtin.set_fact:
-    namespace_corrected: "{{ namespace | regex_replace('^(.+?)(-new)?$', '\\1') }}"
-  vars:
-    namespace: "{{ namespace | default('') }}"
-  when: namespace != namespace | regex_replace('^(.+?)(-new)?$', '\\1')
-
 - name: Create a new ManifestWork for each cluster to patch alertmanager-main secret
   kubernetes.core.k8s:
     state: present
@@ -87,7 +80,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ namespace_corrected }}"
+        namespace: "{{ namespace | regex_replace('^(.*?)(-new)?$', '\\1') | default('default-namespace') }}"
       spec:
         workload:
           manifests:

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -80,7 +80,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ namespace }}"
+        namespace: "{{ item.cluster.name | regex_replace('^(.*?)(-new)?$', '\\1') | default('default') }}"
       spec:
         workload:
           manifests:

--- a/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
+++ b/roles/grafana_cloud_operator/tasks/modify_alertmanager_secret.yml
@@ -72,6 +72,13 @@
     provision_mode_check: "{{ provision_mode }}"
   when: provision_mode_check == "hubAndSpoke"
 
+- name: Adjust namespace if necessary
+  ansible.builtin.set_fact:
+    namespace_corrected: "{{ namespace | regex_replace('^(.+?)(-new)?$', '\\1') }}"
+  vars:
+    namespace: "{{ namespace | default('') }}"
+  when: namespace != namespace | regex_replace('^(.+?)(-new)?$', '\\1')
+
 - name: Create a new ManifestWork for each cluster to patch alertmanager-main secret
   kubernetes.core.k8s:
     state: present
@@ -80,7 +87,7 @@
       kind: ManifestWork
       metadata:
         name: "{{ receiver_name }}-manifestwork-grafana-oncall"
-        namespace: "{{ namespace }}"
+        namespace: "{{ namespace_corrected }}"
       spec:
         workload:
           manifests:


### PR DESCRIPTION
Functionality of added Code in the playbook:
This task automates the creation of Grafana OnCall integrations for managed clusters, based on a list of clusters to be integrated. It includes the following steps:

1. Data Preparation:

  Extracts the list of managed clusters with their associated owners from managed_clusters.
  Filters clusters that need integration based on predefined criteria.

2. Prefix Handling:

  Ensures that cluster names and owners are prefixed with name: and owner: to match the required format for integration creation.

3. Integration Creation:
  
  Iterates over the filtered clusters, creating a new integration in Grafana OnCall for each relevant cluster.
  
  The integration's name is dynamically constructed by concatenating the cluster name and owner (e.g., alpha-test-stakater).
  Slack notification settings are configured for each integration, based on available configurations.